### PR TITLE
Decouple Fault Management from stx-config

### DIFF
--- a/dcmanager/api/controllers/v1/subclouds.py
+++ b/dcmanager/api/controllers/v1/subclouds.py
@@ -13,7 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 #
-# Copyright (c) 2017 Wind River Systems, Inc.
+# Copyright (c) 2017-2018 Wind River Systems, Inc.
 #
 # The right to copy, distribute, modify, or otherwise make use
 # of this software may be licensed only pursuant to the terms
@@ -354,7 +354,8 @@ class SubcloudsController(object):
             ('glance', 'glance'),
             ('neutron', 'neutron'),
             ('heat_admin', 'heat-domain'),
-            ('gnocchi', 'gnocchi')
+            ('gnocchi', 'gnocchi'),
+            ('fm', 'fm')
         ]
 
         user_list = list()

--- a/dcorch/drivers/openstack/fm.py
+++ b/dcorch/drivers/openstack/fm.py
@@ -1,0 +1,53 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# Copyright (c) 2018 Wind River Systems, Inc.
+#
+
+
+from oslo_log import log
+
+import fmclient
+
+from dcorch.common import exceptions
+from dcorch.drivers import base
+
+LOG = log.getLogger(__name__)
+API_VERSION = '1'
+
+
+class FmClient(base.DriverBase):
+    """Fault Management driver."""
+
+    def __init__(self, region, session, endpoint_type):
+        self.region_name = region
+        try:
+            self.fm = fmclient.Client(API_VERSION,
+                                      session=session,
+                                      region_name=region,
+                                      endpoint_type=endpoint_type)
+        except exceptions.ServiceUnavailable:
+            raise
+
+    def get_alarm_summary(self):
+        """Get this region alarm summary
+
+        """
+        try:
+            LOG.info("get_alarm_summary region %s" %
+                     self.region_name)
+            alarms = self.fm.alarm.summary()
+            return alarms
+        except Exception as e:
+            LOG.error("get_alarm_summary exception=%s" % e)
+            pass
+        return {}

--- a/dcorch/drivers/openstack/sdk.py
+++ b/dcorch/drivers/openstack/sdk.py
@@ -29,6 +29,7 @@ from dcorch.drivers.openstack.keystone_v3 import KeystoneClient
 from dcorch.drivers.openstack.neutron_v2 import NeutronClient
 from dcorch.drivers.openstack.nova_v2 import NovaClient
 from dcorch.drivers.openstack.sysinv_v1 import SysinvClient
+from dcorch.drivers.openstack.fm import FmClient
 
 # Gap, in seconds, to determine whether the given token is about to expire
 STALE_TOKEN_DURATION = 60
@@ -71,6 +72,8 @@ class OpenStackDriver(object):
                 region_name]['cinder']
             self.neutron_client = OpenStackDriver.os_clients_dict[
                 region_name]['neutron']
+            self.fm_client = OpenStackDriver.os_clients_dict[
+                region_name]['fm']
         else:
             # Create new objects and cache them
             LOG.info("Creating fresh OS Clients objects %s" % region_name)
@@ -120,6 +123,17 @@ class OpenStackDriver(object):
                     'cinder'] = self.cinder_client
             except Exception as exception:
                 LOG.error('cinder_client region %s error: %s' %
+                          (region_name, exception.message))
+
+            try:
+                self.fm_client = FmClient(
+                    region_name,
+                    self.keystone_client.session,
+                    endpoint_type=consts.KS_ENDPOINT_DEFAULT)
+                OpenStackDriver.os_clients_dict[region_name][
+                    'fm'] = self.fm_client
+            except Exception as exception:
+                LOG.error('fm_client region %s error: %s' %
                           (region_name, exception.message))
 
     @classmethod

--- a/dcorch/drivers/openstack/sysinv_v1.py
+++ b/dcorch/drivers/openstack/sysinv_v1.py
@@ -451,20 +451,6 @@ class SysinvClient(base.DriverBase):
 
         return remotelogging
 
-    def get_alarm_summary(self):
-        """Get this regions alarm summary
-
-        """
-        try:
-            LOG.info("get_alarm_summary region %s" %
-                     self.region_name)
-            alarms = self.client.ialarm.summary()
-            return alarms
-        except Exception as e:
-            LOG.error("get_alarm_summary exception=%s" % e)
-            pass
-        return {}
-
     def get_firewallrules(self):
         """Get the firewallrules for this region
 

--- a/dcorch/engine/alarm_aggregate_manager.py
+++ b/dcorch/engine/alarm_aggregate_manager.py
@@ -21,7 +21,8 @@ from dcorch.common import exceptions
 from dcorch.common.i18n import _
 from dcorch.common import manager
 from dcorch.db import api as db_api
-from dcorch.drivers.openstack import sdk_platform as sdk
+from dcorch.drivers.openstack import sdk_platform
+from dcorch.drivers.openstack import sdk
 
 from oslo_config import cfg
 from oslo_log import log as logging
@@ -52,7 +53,7 @@ class AlarmAggregateManager(manager.Manager):
     def enable_snmp(self, ctxt, subcloud_name):
         LOG.info("Enabling fm-aggregation trap for region_name=%s" %
                  subcloud_name)
-        os_client = sdk.OpenStackDriver(subcloud_name)
+        os_client = sdk_platform.OpenStackDriver(subcloud_name)
         payload = {"ip_address": CONF.snmp.snmp_ip,
                    "community": CONF.snmp.snmp_comm_str}
         try:
@@ -80,7 +81,7 @@ class AlarmAggregateManager(manager.Manager):
         LOG.info("Updating alarm summary for %s" % region_name)
         try:
             os_client = sdk.OpenStackDriver(region_name)
-            alarms = os_client.sysinv_client.get_alarm_summary()
+            alarms = os_client.fm_client.get_alarm_summary()
             alarm_updates = {'critical_alarms': alarms[0].critical,
                              'major_alarms': alarms[0].major,
                              'minor_alarms': alarms[0].minor,


### PR DESCRIPTION
The fault management (FM) APIs has been removed from the syinv API
service and a new FM API service has been introduced. This update adds
a new fm openstack driver for retrieving each region's alarm summary,
and it also modifies the alarm aggregate manager to use the fm driver.
In addition, it removes get alarm summary routine from sysinv and
adds the  fm user to the subcloud user list

Story: 2002828
Task: 22747

Signed-off-by: Tao Liu <tao.liu@windriver.com>