### PR TITLE
Distributed Cloud: Patch Orchestration Loop

### DIFF
--- a/dcmanager/manager/sw_update_manager.py
+++ b/dcmanager/manager/sw_update_manager.py
@@ -435,6 +435,7 @@ class PatchOrchThread(threading.Thread):
                 elif sw_update_strategy.stop_on_failure:
                     # We have been told to stop on failures
                     stop_after_stage = strategy_step.stage
+                    current_stage = strategy_step.stage
                     break
                 continue
             # We have found the first step that isn't complete or failed.


### PR DESCRIPTION
In Distributed Cloud patch orchestration stop-on-failure causes an
exception loop.  Set the current_stage when stopping on failure to
allow patch orchestration to continue on other clouds.

Closes-Bug: 1788882

Signed-off-by: Kristine Bujold <kristine.bujold@windriver.com>